### PR TITLE
add proper support for remote specs

### DIFF
--- a/assets/template.hbs
+++ b/assets/template.hbs
@@ -53,7 +53,7 @@
 <script>
 window.addEventListener("load", function() {
   const ui = SwaggerUIBundle({
-    url: "{{ openapi }}",
+    url: "{{ openApiUrl }}",
     dom_id: '#swagger-ui',
     presets: [
       SwaggerUIBundle.presets.apis,

--- a/assets/template.hbs
+++ b/assets/template.hbs
@@ -53,7 +53,7 @@
 <script>
 window.addEventListener("load", function() {
   const ui = SwaggerUIBundle({
-    url: "{{ url }}",
+    url: "{{ openapi }}",
     dom_id: '#swagger-ui',
     presets: [
       SwaggerUIBundle.presets.apis,

--- a/index.js
+++ b/index.js
@@ -43,9 +43,9 @@ function processFiles(options, files, metalsmith, done) {
     });
     let local = false;
 
-    if (!data.openapi) {
+    if (!data.openApiUrl) {
       local = true;
-      data.openapi = path.basename(file);
+      data.openApiUrl = path.basename(file);
     }
 
     data.swagger = {};
@@ -67,7 +67,7 @@ function processFiles(options, files, metalsmith, done) {
     data.contents = new Buffer(template(data));
 
     files[html] = data;
-    if(local) { // bypass futher processing for local source files
+    if (local) { // bypass futher processing for local source files
       const destination = path.join(metalsmith.destination(), file);
       const dirname = path.dirname(destination);
       fs.ensureDirSync(dirname);
@@ -153,10 +153,10 @@ function copyAssets(options, files, metalsmith, done) {
  *    css/scripts on the default template?
  * @return {Function}
  */
-module.exports = function (opt) {
+module.exports = (opt) => {
   const options = merge({}, defaults, opt);
 
-  return function (files, metalsmith, done) {
+  return (files, metalsmith, done) => {
     async.parallel([
       (callback) => {
         copyAssets(options, files, metalsmith, callback);

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const defaults = {
  * Todo: add yaml parsing and aditional validation
  */
 function isOpenAPI(file) {
-  return /\.(json|yml|yaml)$/.test(path.extname(file));
+  return /\.(json|yml|yaml|openapi)$/.test(path.extname(file));
 }
 
 /**
@@ -41,9 +41,11 @@ function processFiles(options, files, metalsmith, done) {
       name: path.basename(file, path.extname(file)),
       ext: '.html',
     });
+    let local = false;
 
-    if (!data.url) {
-      data.url = path.basename(file);
+    if (!data.openapi) {
+      local = true;
+      data.openapi = path.basename(file);
     }
 
     data.swagger = {};
@@ -65,17 +67,18 @@ function processFiles(options, files, metalsmith, done) {
     data.contents = new Buffer(template(data));
 
     files[html] = data;
+    if(local) { // bypass futher processing for local source files
+      const destination = path.join(metalsmith.destination(), file);
+      const dirname = path.dirname(destination);
+      fs.ensureDirSync(dirname);
 
-    // bypass futher processing for source file
-    const destination = path.join(metalsmith.destination(), file);
-    const dirname = path.dirname(destination);
-    fs.ensureDirSync(dirname);
+      fs.writeFileSync(destination, files[file].contents, (err) => {
+        if (err) {
+          throw err;
+        }
+      });
+    }
 
-    fs.writeFileSync(destination, files[file].contents, (err) => {
-      if (err) {
-        throw err;
-      }
-    });
     delete files[file];
   });
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "handlebars": "^4.0.10",
     "merge": "^1.2.0",
     "recursive-readdir": "^2.2.1",
-    "swagger-ui-dist": "^3.0.17"
+    "swagger-ui-dist": "^3.0.19"
   },
   "devDependencies": {
     "expect": "^1.20.2",

--- a/test/assets/customTemplate.hbs
+++ b/test/assets/customTemplate.hbs
@@ -53,7 +53,7 @@
 <script>
 window.addEventListener("load", function() {
   const ui = SwaggerUIBundle({
-    url: "{{ openapi }}",
+    url: "{{ openApiUrl }}",
     dom_id: '#swagger-ui',
     presets: [
       SwaggerUIBundle.presets.apis,

--- a/test/assets/customTemplate.hbs
+++ b/test/assets/customTemplate.hbs
@@ -53,7 +53,7 @@
 <script>
 window.addEventListener("load", function() {
   const ui = SwaggerUIBundle({
-    url: "{{ url }}",
+    url: "{{ openapi }}",
     dom_id: '#swagger-ui',
     presets: [
       SwaggerUIBundle.presets.apis,

--- a/test/assets/fixtures/petstore-minimal.yml
+++ b/test/assets/fixtures/petstore-minimal.yml
@@ -1,47 +1,48 @@
 ---
+  metalsmith-swagger-ui: 2
+---
   swagger: "2.0"
-  info: 
+  info:
     version: "1.0.0"
     title: "Swagger Petstore"
     description: "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification"
     termsOfService: "http://swagger.io/terms/"
-    contact: 
+    contact:
       name: "Swagger API Team"
-    license: 
+    license:
       name: "MIT"
   host: "petstore.swagger.io"
   basePath: "/api"
-  schemes: 
+  schemes:
     - "http"
-  consumes: 
+  consumes:
     - "application/json"
-  produces: 
+  produces:
     - "application/json"
-  paths: 
-    /pets: 
-      get: 
+  paths:
+    /pets:
+      get:
         description: "Returns all pets from the system that the user has access to"
-        produces: 
+        produces:
           - "application/json"
-        responses: 
+        responses:
           "200":
             description: "A list of pets."
-            schema: 
+            schema:
               type: "array"
-              items: 
+              items:
                 $ref: "#/definitions/Pet"
-  definitions: 
-    Pet: 
+  definitions:
+    Pet:
       type: "object"
-      required: 
+      required:
         - "id"
         - "name"
-      properties: 
-        id: 
+      properties:
+        id:
           type: "integer"
           format: "int64"
-        name: 
+        name:
           type: "string"
-        tag: 
+        tag:
           type: "string"
-

--- a/test/assets/fixtures/petstore-simple.yaml
+++ b/test/assets/fixtures/petstore-simple.yaml
@@ -1,157 +1,158 @@
 ---
+  metalsmith-swagger-ui: 2
+---
   swagger: "2.0"
-  info: 
+  info:
     version: "1.0.0"
     title: "Swagger Petstore"
     description: "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification"
     termsOfService: "http://swagger.io/terms/"
-    contact: 
+    contact:
       name: "Swagger API Team"
-    license: 
+    license:
       name: "MIT"
   host: "petstore.swagger.io"
   basePath: "/api"
-  schemes: 
+  schemes:
     - "http"
-  consumes: 
+  consumes:
     - "application/json"
-  produces: 
+  produces:
     - "application/json"
-  paths: 
-    /pets: 
-      get: 
+  paths:
+    /pets:
+      get:
         description: "Returns all pets from the system that the user has access to"
         operationId: "findPets"
-        produces: 
+        produces:
           - "application/json"
           - "application/xml"
           - "text/xml"
           - "text/html"
-        parameters: 
-          - 
+        parameters:
+          -
             name: "tags"
             in: "query"
             description: "tags to filter by"
             required: false
             type: "array"
-            items: 
+            items:
               type: "string"
             collectionFormat: "csv"
-          - 
+          -
             name: "limit"
             in: "query"
             description: "maximum number of results to return"
             required: false
             type: "integer"
             format: "int32"
-        responses: 
+        responses:
           "200":
             description: "pet response"
-            schema: 
+            schema:
               type: "array"
-              items: 
+              items:
                 $ref: "#/definitions/Pet"
-          default: 
+          default:
             description: "unexpected error"
-            schema: 
+            schema:
               $ref: "#/definitions/ErrorModel"
-      post: 
+      post:
         description: "Creates a new pet in the store.  Duplicates are allowed"
         operationId: "addPet"
-        produces: 
+        produces:
           - "application/json"
-        parameters: 
-          - 
+        parameters:
+          -
             name: "pet"
             in: "body"
             description: "Pet to add to the store"
             required: true
-            schema: 
+            schema:
               $ref: "#/definitions/NewPet"
-        responses: 
+        responses:
           "200":
             description: "pet response"
-            schema: 
+            schema:
               $ref: "#/definitions/Pet"
-          default: 
+          default:
             description: "unexpected error"
-            schema: 
+            schema:
               $ref: "#/definitions/ErrorModel"
-    /pets/{id}: 
-      get: 
+    /pets/{id}:
+      get:
         description: "Returns a user based on a single ID, if the user does not have access to the pet"
         operationId: "findPetById"
-        produces: 
+        produces:
           - "application/json"
           - "application/xml"
           - "text/xml"
           - "text/html"
-        parameters: 
-          - 
+        parameters:
+          -
             name: "id"
             in: "path"
             description: "ID of pet to fetch"
             required: true
             type: "integer"
             format: "int64"
-        responses: 
+        responses:
           "200":
             description: "pet response"
-            schema: 
+            schema:
               $ref: "#/definitions/Pet"
-          default: 
+          default:
             description: "unexpected error"
-            schema: 
+            schema:
               $ref: "#/definitions/ErrorModel"
-      delete: 
+      delete:
         description: "deletes a single pet based on the ID supplied"
         operationId: "deletePet"
-        parameters: 
-          - 
+        parameters:
+          -
             name: "id"
             in: "path"
             description: "ID of pet to delete"
             required: true
             type: "integer"
             format: "int64"
-        responses: 
+        responses:
           "204":
             description: "pet deleted"
-          default: 
+          default:
             description: "unexpected error"
-            schema: 
+            schema:
               $ref: "#/definitions/ErrorModel"
-  definitions: 
-    Pet: 
+  definitions:
+    Pet:
       type: "object"
-      allOf: 
-        - 
+      allOf:
+        -
           $ref: "#/definitions/NewPet"
-        - 
-          required: 
+        -
+          required:
             - "id"
-          properties: 
-            id: 
+          properties:
+            id:
               type: "integer"
               format: "int64"
-    NewPet: 
+    NewPet:
       type: "object"
-      required: 
+      required:
         - "name"
-      properties: 
-        name: 
+      properties:
+        name:
           type: "string"
-        tag: 
+        tag:
           type: "string"
-    ErrorModel: 
+    ErrorModel:
       type: "object"
-      required: 
+      required:
         - "code"
         - "message"
-      properties: 
-        code: 
+      properties:
+        code:
           type: "integer"
           format: "int32"
-        message: 
+        message:
           type: "string"
-

--- a/test/assets/fixtures/remote.openapi
+++ b/test/assets/fixtures/remote.openapi
@@ -1,3 +1,3 @@
 ---
-openapi: http://petstore.swagger.io/v2/swagger.json
+openApiUrl: http://petstore.swagger.io/v2/swagger.json
 ---

--- a/test/assets/fixtures/remote.openapi
+++ b/test/assets/fixtures/remote.openapi
@@ -1,0 +1,3 @@
+---
+openapi: http://petstore.swagger.io/v2/swagger.json
+---

--- a/test/assets/fixtures/resource.example
+++ b/test/assets/fixtures/resource.example
@@ -1,0 +1,1 @@
+This is a resource

--- a/test/test.js
+++ b/test/test.js
@@ -11,15 +11,12 @@ before((done) => {
     .clean(true)
     .use(metalsmithSwaggerUi())
     .build((err) => {
-      if (err) {
-        done(err);
-      } else {
-        done();
-      }
+      if (err) throw done(err);
+      done();
     });
 });
 
-describe('metalsmith-swaggerui', () => {
+describe('metalsmith-swagger-ui', () => {
   describe('#isOpenAPI', () => {
     it('should match .json files', () => {
       expect(fs.existsSync(path.join(__dirname, 'build', 'petstore.html'))).toBe(true);
@@ -31,6 +28,10 @@ describe('metalsmith-swaggerui', () => {
 
     it('should match .yml files', () => {
       expect(fs.existsSync(path.join(__dirname, 'build', 'petstore-minimal.html'))).toBe(true);
+    });
+
+    it('should match .openapi files', () => {
+      expect(fs.existsSync(path.join(__dirname, 'build', 'remote.html'))).toBe(true);
     });
 
     it.skip('should not match invalid Open API specs', () => {
@@ -49,6 +50,23 @@ describe('metalsmith-swaggerui', () => {
 
     it('should leave other files untouched', () => {
       expect(fs.existsSync(path.join(__dirname, 'build', 'json.json'))).toBe(true);
+      expect(fs.existsSync(path.join(__dirname, 'build', 'resource.example'))).toBe(true);
+    });
+
+    it('should link local specs', (done) => {
+      fs.readFile(path.join(__dirname, 'build', 'petstore.html'), (err, data) => {
+        if (err) throw done(err);
+        expect(data.toString()).toMatch(/petstore\.json/);
+        done();
+      });
+    });
+
+    it('should link remote specs', (done) => {
+      fs.readFile(path.join(__dirname, 'build', 'remote.html'), (err, data) => {
+        if (err) throw done(err);
+        expect(data.toString()).toMatch(/http:\/\/petstore.swagger\.io\/v2\/swagger\.json/);
+        done();
+      });
     });
   });
 
@@ -66,11 +84,8 @@ describe('metalsmith-swaggerui', () => {
           integrateAssets: false,
         }))
         .build((err) => {
-          if (err) {
-            done(err);
-          } else {
-            done();
-          }
+          if (err) throw done(err);
+          done();
         });
     });
 


### PR DESCRIPTION
Renamed metadata tag `url` to `openapi` to avoid conflict with other metalsmith plugins.
Add `openapi` file extention so that there is a file format for remote specs.